### PR TITLE
Update contributing instructions and a couple of collectors to support CRIBL-21704

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,22 @@ Each template directory must include a README file with a minimum set of details
 
 The collector template must be included in a file `collector.json`. The template must pass an import to a Cribl Stream instance as committed.
 
-Any relevant event breaker templates must be added to a file `breakers.json`. The event breakers.
+Any relevant event breaker templates must be added to a file `breakers.json`.
+
+### Placeholders
+
+Placeholders should use the the format `<Placeholder|Description>`. For example,
+```
+"collectRequestHeaders": [
+  {
+    "name": "X-FOO-API-KEY",
+    "value": "'<FOO API Key|The API key associated with your FOO account>'"
+  }
+],
+```
+
+When following this pattern, Cribl (v4.4.4 and later) can recognize placeholders and prompt the user to fill them in on config import.
+
 
 ## Sample Data
 

--- a/collectors/rest/alienvault/collector.json
+++ b/collectors/rest/alienvault/collector.json
@@ -64,7 +64,7 @@
       "collectRequestHeaders": [
         {
           "name": "X-OTX-API-KEY",
-          "value": "'<your-otx-api-key>'"
+          "value": "'<OTX API Key|Your OTX Key (sign up for a key at [otx.alienvault.com](https://otx.alienvault.com/#signup))>'"
         }
       ],
       "collectRequestParams": [

--- a/collectors/rest/cribl_metrics/collector.json
+++ b/collectors/rest/cribl_metrics/collector.json
@@ -28,7 +28,7 @@
       "authRequestParams": [
         {
           "name": "client_id",
-          "value": "<CLIENT_ID>"
+          "value": "<Client ID|Client ID from a Cribl Cloud Credential>"
         },
         {
           "name": "audience",
@@ -39,7 +39,7 @@
           "value": "'client_credentials'"
         }
       ],
-      "collectUrl": "`https://main-<ORG_ID>.cribl.cloud/api/v1/system/metrics`",
+      "collectUrl": "`https://main-<Organization ID|Cribl Cloud organization ID>.cribl.cloud/api/v1/system/metrics`",
       "collectRequestParams": [
         {
           "name": "earliest",
@@ -54,7 +54,7 @@
           "value": "'application/json'"
         }
       ],
-      "clientSecretParamValue": "<CLIENT_SECRET>"
+      "clientSecretParamValue": "<Client Secret|Client Secret from a Cribl Cloud Credential>"
     },
     "destructive": false,
     "type": "rest"

--- a/collectors/rest/cribl_metrics/collector.json
+++ b/collectors/rest/cribl_metrics/collector.json
@@ -25,10 +25,11 @@
       "authHeaderKey": "Authorization",
       "authHeaderExpr": "`Bearer ${token}`",
       "clientSecretParamName": "client_secret",
+      "collectUrl": "`https://main-<Organization ID|Cribl Cloud organization ID>.cribl.cloud/api/v1/system/metrics`",
       "authRequestParams": [
         {
           "name": "client_id",
-          "value": "<Client ID|Client ID from a Cribl Cloud Credential>"
+          "value": "'<Client ID|To generate a credential, see [Cribl Documentation](https://docs.cribl.io/stream/api-tutorials/#create-credential)>'"
         },
         {
           "name": "audience",
@@ -39,7 +40,6 @@
           "value": "'client_credentials'"
         }
       ],
-      "collectUrl": "`https://main-<Organization ID|Cribl Cloud organization ID>.cribl.cloud/api/v1/system/metrics`",
       "collectRequestParams": [
         {
           "name": "earliest",
@@ -54,7 +54,7 @@
           "value": "'application/json'"
         }
       ],
-      "clientSecretParamValue": "<Client Secret|Client Secret from a Cribl Cloud Credential>"
+      "clientSecretParamValue": "<Client Secret|To generate a credential, see [Cribl Documentation](https://docs.cribl.io/stream/api-tutorials/#create-credential)>"
     },
     "destructive": false,
     "type": "rest"


### PR DESCRIPTION
CRIBL-21704 adds support for parsing placeholders from imported configs. This PR adds instructions for placeholder format, and updates two collectors (picked ones that I was able to test) to follow the proper format.

I started looking at a few of the other collectors in the repo to update those as well, but I don't have the necessary accounts or api keys for most of them. Once the changes for CRIBL-21704 are available on cloud staging, I'm hoping to reach out and collaborate to get the rest of the configs here updated to adhere to the new placeholder format.