### PR TITLE
Use configurationFindings in breaker for Wiz configurationFindings

### DIFF
--- a/collectors/rest/wiz/breaker.json
+++ b/collectors/rest/wiz/breaker.json
@@ -21,7 +21,7 @@
       "eventBreakerRegex": "/[\\n\\r]+(?!\\s)/",
       "jsonArrayField": "data.configurationFindings.nodes",
       "name": "configurationFindings",
-      "jsonTimeField": "createdAt"
+      "jsonTimeField": "firstSeenAt"
     },
     {
       "condition": "_raw.startsWith('{\"data\":{\"issues\":{\"nodes\":')",


### PR DESCRIPTION
We use `firstSeenAt` when filtering configuration findings for delta updates, so we should also use that in the corresponding breaker.