### PR TITLE
Update cribl-leader-logs event breaker to extract fields by default

### DIFF
--- a/collectors/rest/cribl-leader-logs/cribl-leader-logs-breaker.json
+++ b/collectors/rest/cribl-leader-logs/cribl-leader-logs-breaker.json
@@ -1,5 +1,5 @@
 {
-  "id": "cribl-cloud-leader-logs-breaker-v1",
+  "id": "cribl-cloud-leader-logs-breaker-v2",
   "minRawLength": 256,
   "rules": [
     {
@@ -17,7 +17,7 @@
       "disabled": false,
       "parserEnabled": false,
       "shouldUseDataRaw": false,
-      "jsonExtractAll": false,
+      "jsonExtractAll": true,
       "eventBreakerRegex": "/[\\n\\r]+(?!\\s)/",
       "name": "default",
       "jsonArrayField": "items.events"


### PR DESCRIPTION
By default, this will give me an event with only a JSON string in `_raw`.
IMHO it should auto-extract the fields, because you'll likely work with them, and the events are then pretty close to what the Cribl Logs source of the workers will produce, so you can run them through the same pipeline, because both will have all fields at the top level available.
If you think it shouldn't be that way, I'm also fine with that ;-)